### PR TITLE
Use gnu++14 instead of c++14 for esp-idf

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,7 @@ framework = espidf
 upload_speed=1843200
 monitor_speed=115200
 build_unflags=-std=gnu++11
-build_flags=-std=c++14
+build_flags=-std=gnu++14
             -DFRAMEWORK_ESP_IDF
             -DESP_WROVER_KIT
             -DILI9341
@@ -23,7 +23,7 @@ board_build.partitions = no_ota.csv
 framework = espidf
 upload_speed = 921600
 monitor_speed = 115200
-build_flags=-std=c++14
+build_flags=-std=gnu++14
             -DFRAMEWORK_ESP_IDF
             -DESP32_TTGO
             -DST7789
@@ -37,7 +37,7 @@ build_unflags=-std=gnu++11
 ;framework = espidf
 ;upload_speed = 921600
 ;monitor_speed = 115200
-;build_flags=-std=c++14
+;build_flags=-std=gnu++14
 ;            -DFRAMEWORK_ESP_IDF
 ;            -DESP32_TWATCH
 ;            -DST7789
@@ -51,7 +51,7 @@ framework = espidf
 upload_speed = 921600
 monitor_speed = 115200
 build_unflags=-std=gnu++11
-build_flags=-std=c++14
+build_flags=-std=gnu++14
             -DFRAMEWORK_ESP_IDF
             -DST7735
 
@@ -63,7 +63,7 @@ framework = espidf
 upload_speed = 921600
 monitor_speed = 115200
 build_unflags=-std=gnu++11
-build_flags=-std=c++14
+build_flags=-std=gnu++14
             -DFRAMEWORK_ESP_IDF
             -DILI9341
 
@@ -75,7 +75,7 @@ framework = espidf
 upload_speed = 921600
 monitor_speed = 115200
 build_unflags=-std=gnu++11
-build_flags=-std=c++14
+build_flags=-std=gnu++14
             -DFRAMEWORK_ESP_IDF
             -DST7789
 
@@ -87,7 +87,7 @@ framework = espidf
 upload_speed = 921600
 monitor_speed = 115200
 build_unflags=-std=gnu++11
-build_flags=-std=c++14
+build_flags=-std=gnu++14
             -DFRAMEWORK_ESP_IDF
             -DSSD1306
 
@@ -99,7 +99,7 @@ framework = espidf
 upload_speed = 921600
 monitor_speed = 115200
 build_unflags=-std=gnu++11
-build_flags=-std=c++14
+build_flags=-std=gnu++14
             -DFRAMEWORK_ESP_IDF
             -DSSD1351
 
@@ -111,7 +111,7 @@ framework = espidf
 upload_speed = 921600
 monitor_speed = 115200
 build_unflags=-std=gnu++11
-build_flags=-std=c++14
+build_flags=-std=gnu++14
             -DFRAMEWORK_ESP_IDF
             -DMAX7219
 
@@ -123,7 +123,7 @@ framework = espidf
 upload_speed = 921600
 monitor_speed = 115200
 build_unflags=-std=gnu++11
-build_flags=-std=c++14
+build_flags=-std=gnu++14
             -DFRAMEWORK_ESP_IDF
             -DGDEH0154Z90
 
@@ -136,7 +136,7 @@ build_flags=-std=c++14
 ;upload_speed = 921600
 ;monitor_speed = 115200
 ;build_unflags=-std=gnu++11
-;build_flags=-std=c++14
+;build_flags=-std=gnu++14
 ;            -DFRAMEWORK_ESP_IDF
 ;            -DDEPG0290B
 ;            -DT5_22
@@ -150,7 +150,7 @@ build_flags=-std=c++14
 ;upload_speed = 921600
 ;monitor_speed = 115200
 ;build_unflags=-std=gnu++11
-;build_flags=-std=c++14
+;build_flags=-std=gnu++14
 ;            -DFRAMEWORK_ESP_IDF
 ;            -DRA8875
 


### PR DESCRIPTION
ESP-IDF has a macro expansion issue for __VA_RAGS__ when gnu compiler extension is disabled.

The esp32 build fails with xtensa-esp32-elf-c++ 8.4.0 because of espressif/esp-idf#5897